### PR TITLE
Api Enhancements

### DIFF
--- a/gen_ai/common/bq_utils.py
+++ b/gen_ai/common/bq_utils.py
@@ -280,7 +280,7 @@ class BigQueryConverter:
     """
 
     @staticmethod
-    def convert_query_state_to_prediction(query_state: QueryState, log_snapshots: list[dict]) -> pd.DataFrame:
+    def convert_query_state_to_prediction(query_state: QueryState, log_snapshots: list[dict], session_id: str) -> pd.DataFrame:
         data = {
             "user_id": [],
             "prediction_id": [],
@@ -309,7 +309,6 @@ class BigQueryConverter:
             "plan_and_summaries": [],
         }
         max_round = len(log_snapshots) - 1
-        session_id = Container.session_id if hasattr(Container, "session_id") else str(uuid.uuid4())
         system_state_id = Container.system_state_id or log_system_status(session_id)
         for round_number, log_snapshot in enumerate(log_snapshots):
             react_round_number = round_number

--- a/gen_ai/common/document_retriever.py
+++ b/gen_ai/common/document_retriever.py
@@ -115,7 +115,7 @@ class SemanticDocumentRetriever(DocumentRetriever):
         ss_docs = [x[0] for x in ss_docs[0:3]]
 
         mmr_docs = store.max_marginal_relevance_search(
-            query=questions_for_search, k=2, lambda_mult=0.5, filter=metadata
+            query=questions_for_search, k=1, lambda_mult=0.5, filter=metadata
         )
         docs = common.remove_duplicates(ss_docs + mmr_docs)
 

--- a/gen_ai/deploy/api.py
+++ b/gen_ai/deploy/api.py
@@ -60,7 +60,11 @@ def respond(query: ItemInput) -> LLMOutput:
         additional_information_to_retrieve="",
         context_used=conversation.exchanges[-1].relevant_context,
         urls_to_kc=conversation.exchanges[-1].urls,
-        sections_to_b360=[""],
+        attributes_to_b360=conversation.exchanges[-1].attributes_to_b360,
+        attributes_to_kc_km=conversation.exchanges[-1].attributes_to_kc_km,
+        attributes_to_kc_mp=conversation.exchanges[-1].attributes_to_kc_mp,
+        confidence_score=str(conversation.exchanges[-1].confidence_score),
+        session_id=conversation.session_id,
     )
 
     return response

--- a/gen_ai/deploy/model.py
+++ b/gen_ai/deploy/model.py
@@ -87,10 +87,24 @@ class LLMOutput(BaseModel):
         urls_to_kc (list[str]): A list of URLs to knowledge components that were referenced or
                                 could be relevant to the response. This can help users to explore
                                 related topics or verify information.
-        sections_to_b360 (list[str]): A list of sections or identifiers within a broader system
-                                      (like B360) that are relevant to the response. This is useful
-                                      for integrating the AI's responses with other systems or databases.
+        attributes_to_kc_km (list[dict[str, str, str]]): A list of quatrlets:
+                                - Document type (can be "KM" or "MP"), both come from KC
+                                - Document identifier (doc_identifier for KM, original_filepath for MP)
+                                - URL (exists only for KM, is empty for MP)
+                                - Section Name (exists for all: B360, KC KM, KC MP)
+                                This can help users to explore related topics or verify information.
+        attributes_to_kc_mp (list[dict[str, str, str]]): A list of quatrlets:
+                                - Document type (can be "KM" or "MP"), both come from KC
+                                - Original filepath (original_filepath for MP)
+                                - Policy number (exists only for MP, is empty for KM)
+                                - Section Name (exists for all: B360, KC KM, KC MP)
+                                This can help users to explore related topics or verify information.
+        attributes_to_b360 (list[dict[str, str]]): A list of tuples:
+                                - Set number, exists only in b360 
+                                - Section name, name of the chunk from B360
+                                This is useful for integrating the AI's responses with other systems or databases.
         confidence_score (str): The conversation confidence_score, indicating how confident was the answer.
+        session_id (str): The conversation session_id, which can be used to track the answers in BigQuery.
 
     Note:
         The attributes `plan_and_summaries`, `additional_information_to_retrieve`, `context_used`,
@@ -105,7 +119,11 @@ class LLMOutput(BaseModel):
     additional_information_to_retrieve: str
     context_used: str
     urls_to_kc: list[str]
-    sections_to_b360: list[str]
+    attributes_to_kc_km: list[dict]
+    attributes_to_kc_mp: list[dict]
+    attributes_to_b360: list[dict]
+    confidence_score: str
+    session_id: str
 
 
 @dataclass
@@ -126,7 +144,10 @@ class QueryState:
         used_articles_with_scores: A list of the articles that were used to generate the answer with the scores.
         additional_information_to_retrieve: Any additional information that needs to be retrieved.
         time_taken: The time taken to generate the answer.
-        retrieved_docs: Documents that were retrieved during the answering
+        confidence_score: Confidence score of the answer of the final round
+        attributes_to_kc_km: List of dictionaries, that represents information from KC, type KM. See LLMOutput
+        attributes_to_kc_mp: List of dictionaries, that represents information from KC, type MP. See LLMOutput
+        attributes_to_b360: List of dictionaries, that represents information from B360. See LLMOutput
     """
 
     question: str
@@ -143,6 +164,10 @@ class QueryState:
     additional_information_to_retrieve: str | None = field(default=None)
     time_taken: int = field(default=0)
     confidence_score: int = field(default=0)
+    attributes_to_kc_km: list[dict[str, str, str]] = field(default_factory=list)
+    attributes_to_kc_mp: list[dict[str, str, str]] = field(default_factory=list)
+    attributes_to_b360: list[dict[str, str]]= field(default_factory=list)
+
 
 
 @dataclass

--- a/gen_ai/llm.py
+++ b/gen_ai/llm.py
@@ -28,6 +28,7 @@ Dependencies:
 
 from timeit import default_timer
 from typing import Any
+import uuid
 
 import json5
 from dependency_injector.wiring import inject
@@ -355,12 +356,65 @@ def generate_response_react(conversation: Conversation) -> tuple[Conversation, l
     conversation.round_numder = round_number
     query_state.answer = output["answer"]
     query_state.relevant_context = output["context_used"]
-    query_state.urls = list(set(document.metadata["url"] for document in post_filtered_docs))
     query_state.all_sections_needed = [x[0] for x in query_state.used_articles_with_scores]
     query_state.used_articles_with_scores = None
     query_state.confidence_score = confidence
+    query_state = fill_query_state_with_doc_attributes(query_state, post_filtered_docs)
 
     return conversation, log_snapshots
+
+
+def fill_query_state_with_doc_attributes(query_state: QueryState, post_filtered_docs: list[Document]) -> QueryState:
+    """
+    Updates the provided query_state object with attributes extracted from documents after filtering.
+
+    This function modifies the query_state object by setting various attributes based on the metadata of documents in the post_filtered_docs list. It processes documents to categorize them by their data source (B360, KM or MP from KC), and updates the query_state with URLs, and categorized attributes for each type.
+
+    Args:
+        query_state (QueryState): The query state object that needs to be updated with document attributes.
+        post_filtered_docs (list[Document]): A list of Document objects that have been filtered and whose attributes are to be extracted.
+
+    Returns:
+        QueryState: The updated query state object with new attributes set based on the provided documents.
+
+    Side effects:
+        Modifies the query_state object by setting the following attributes:
+        - urls: A set of unique URLs extracted from the document metadata.
+        - attributes_to_b360: A list of dictionaries with attributes from B360 documents.
+        - attributes_to_kc_km: A list of dictionaries with attributes from KC KM documents.
+        - attributes_to_kc_mp: A list of dictionaries with attributes from KC MP documents.
+
+    """
+    query_state.urls = list(set(document.metadata["url"] for document in post_filtered_docs))
+
+    # B360 documents
+    b360_docs = [x for x in post_filtered_docs if x.metadata["data_source"] == "b360"]
+    attributes_to_b360 = [
+        {"set_number": x.metadata["set_number"], "section_name": x.metadata["section_name"]} for x in b360_docs
+    ]
+
+    # KC documents, they can be of two types: from KM (dont have policy number) and from MP (have policy number)
+    kc_docs = [x for x in post_filtered_docs if x.metadata["data_source"] == "kc"]
+    kc_km_docs = [x for x in kc_docs if not x.metadata["policy_number"]]
+    kc_mp_docs = [x for x in kc_docs if x.metadata["policy_number"]]
+
+    attributes_to_kc_km = [
+        {"doc_type": "km", "doc_identifier": x.metadata["doc_identifier"], "url": x.metadata["url"], "section_name": x.metadata['section_name']} for x in kc_km_docs
+    ]
+    attributes_to_kc_mp = [
+        {
+            "doc_type": "mp",
+            "original_filepath": x.metadata["original_filepath"],
+            "policy_number": x.metadata["policy_number"],
+            "section_name": x.metadata['section_name']
+        }
+        for x in kc_mp_docs
+    ]
+
+    query_state.attributes_to_b360 = attributes_to_b360
+    query_state.attributes_to_kc_km = attributes_to_kc_km
+    query_state.attributes_to_kc_mp = attributes_to_kc_mp
+    return query_state
 
 
 def respond(conversation: Conversation, member_info: dict) -> Conversation:
@@ -393,12 +447,14 @@ def respond(conversation: Conversation, member_info: dict) -> Conversation:
     if statefullness_enabled:
         serialize_response(conversation)
 
-    df = BigQueryConverter.convert_query_state_to_prediction(conversation.exchanges[-1], log_snapshots)
+    session_id = Container.session_id if hasattr(Container, "session_id") else str(uuid.uuid4())
+    df = BigQueryConverter.convert_query_state_to_prediction(conversation.exchanges[-1], log_snapshots, session_id)
     client = create_bq_client()
     dataset_id = get_dataset_id()
     table_id = f"{dataset_id}.prediction"
     load_data_to_bq(client, table_id, schema_prediction, df)
 
+    conversation.session_id = session_id
     return conversation
 
 

--- a/gen_ai/llm.py
+++ b/gen_ai/llm.py
@@ -368,11 +368,14 @@ def fill_query_state_with_doc_attributes(query_state: QueryState, post_filtered_
     """
     Updates the provided query_state object with attributes extracted from documents after filtering.
 
-    This function modifies the query_state object by setting various attributes based on the metadata of documents in the post_filtered_docs list. It processes documents to categorize them by their data source (B360, KM or MP from KC), and updates the query_state with URLs, and categorized attributes for each type.
+    This function modifies the query_state object by setting various attributes based on the metadata of documents 
+    in the post_filtered_docs list. It processes documents to categorize them by their data source 
+    (B360, KM or MP from KC), and updates the query_state with URLs, and categorized attributes for each type.
 
     Args:
         query_state (QueryState): The query state object that needs to be updated with document attributes.
-        post_filtered_docs (list[Document]): A list of Document objects that have been filtered and whose attributes are to be extracted.
+        post_filtered_docs (list[Document]): A list of Document objects that have been filtered and whose attributes 
+        are to be extracted.
 
     Returns:
         QueryState: The updated query state object with new attributes set based on the provided documents.
@@ -399,14 +402,20 @@ def fill_query_state_with_doc_attributes(query_state: QueryState, post_filtered_
     kc_mp_docs = [x for x in kc_docs if x.metadata["policy_number"]]
 
     attributes_to_kc_km = [
-        {"doc_type": "km", "doc_identifier": x.metadata["doc_identifier"], "url": x.metadata["url"], "section_name": x.metadata['section_name']} for x in kc_km_docs
+        {
+            "doc_type": "km",
+            "doc_identifier": x.metadata["doc_identifier"],
+            "url": x.metadata["url"],
+            "section_name": x.metadata["section_name"],
+        }
+        for x in kc_km_docs
     ]
     attributes_to_kc_mp = [
         {
             "doc_type": "mp",
             "original_filepath": x.metadata["original_filepath"],
             "policy_number": x.metadata["policy_number"],
-            "section_name": x.metadata['section_name']
+            "section_name": x.metadata["section_name"],
         }
         for x in kc_mp_docs
     ]


### PR DESCRIPTION
## Description
This PR adds several fields to the LLMOutput to help track used documents. We add 3 fields:
  -  attributes_to_kc_km: list[dict]
  -  attributes_to_kc_mp: list[dict]
  -  attributes_to_b360: list[dict]
 This fields contain information that are needed to connect used documents with the databases.

Additionally to that, we add confidence_score and session_id.

## Testing
Manual testing with api.py
