### PR TITLE
Add transform

### DIFF
--- a/gen_ai/deploy/model.py
+++ b/gen_ai/deploy/model.py
@@ -21,6 +21,21 @@ from typing import Any
 from pydantic import BaseModel
 
 
+def transform_to_dictionary(base_model: BaseModel) -> dict:
+    """
+    Transform a Pydantic BaseModel instance into a dictionary containing only
+    attributes that do not have their default values.
+
+    Args:
+        base_model (BaseModel): An instance of a Pydantic BaseModel.
+
+    Returns:
+        dict: A dictionary with keys and values from the BaseModel instance where
+              the values are not equal to their defined default values.
+    """
+    return {k: v for k, v in base_model.model_dump().items() if v != base_model.model_fields[k].default}
+
+
 class PersonalizedData(BaseModel):
     member_id: str = ""
     policy_title: str = ""
@@ -100,7 +115,7 @@ class LLMOutput(BaseModel):
                                 - Section Name (exists for all: B360, KC KM, KC MP)
                                 This can help users to explore related topics or verify information.
         attributes_to_b360 (list[dict[str, str]]): A list of tuples:
-                                - Set number, exists only in b360 
+                                - Set number, exists only in b360
                                 - Section name, name of the chunk from B360
                                 This is useful for integrating the AI's responses with other systems or databases.
         confidence_score (str): The conversation confidence_score, indicating how confident was the answer.
@@ -166,8 +181,7 @@ class QueryState:
     confidence_score: int = field(default=0)
     attributes_to_kc_km: list[dict[str, str, str]] = field(default_factory=list)
     attributes_to_kc_mp: list[dict[str, str, str]] = field(default_factory=list)
-    attributes_to_b360: list[dict[str, str]]= field(default_factory=list)
-
+    attributes_to_b360: list[dict[str, str]] = field(default_factory=list)
 
 
 @dataclass

--- a/gen_ai/llm.py
+++ b/gen_ai/llm.py
@@ -45,7 +45,7 @@ from gen_ai.common.retriever import perform_retrieve_round, retrieve_initial_doc
 from gen_ai.common.statefullness import resolve_and_enrich, serialize_response
 from gen_ai.constants import MAX_CONTEXT_SIZE
 from gen_ai.create_tables import schema_prediction
-from gen_ai.deploy.model import Conversation, PersonalizedData, QueryState
+from gen_ai.deploy.model import Conversation, PersonalizedData, QueryState, transform_to_dictionary
 
 
 @inject
@@ -467,7 +467,7 @@ def respond(conversation: Conversation, member_info: dict) -> Conversation:
     return conversation
 
 
-def respond_api(question: str, member_context_full: PersonalizedData) -> Conversation:
+def respond_api(question: str, member_context_full: PersonalizedData | dict[str, str]) -> Conversation:
     """
     Provides an API-like interface to handle and respond to a new question within a conversation context.
 
@@ -485,6 +485,8 @@ def respond_api(question: str, member_context_full: PersonalizedData) -> Convers
     Raises:
         Exception: If the conversation processing fails at any step.
     """
+    if isinstance(member_context_full, PersonalizedData):
+        member_context_full = transform_to_dictionary(member_context_full)
     query_state = QueryState(question=question, all_sections_needed=[])
     conversation = Conversation(exchanges=[query_state])
     conversation = respond(conversation, member_context_full)

--- a/gen_ai/tests/test_api_model.py
+++ b/gen_ai/tests/test_api_model.py
@@ -1,0 +1,21 @@
+import pytest
+from pydantic import BaseModel
+from gen_ai.deploy.model import transform_to_dictionary
+
+
+class TestDataModel(BaseModel):
+    name: str = ""
+    age: int = 0
+    active: bool = False
+
+
+def test_default_values_omitted():
+    model = TestDataModel(name="John")
+    transformed = transform_to_dictionary(model)
+    assert transformed == {"name": "John"}, "Should only contain the non-default name field"
+
+
+def test_no_default_values():
+    model = TestDataModel(name="John", age=30, active=True)
+    transformed = transform_to_dictionary(model)
+    assert transformed == {"name": "John", "age": 30, "active": True}, "Should contain all fields as none are default"


### PR DESCRIPTION
## Description
This PR adds `transform_to_dictionary` method which is invoked in the API regime. This method keeps only keys and values that dont have default values, such that the metadata filtering in retriever can work correctly.

## Testing
Launch server: `uvicorn gen_ai.deploy.api:app --reload --port 8080`
Launch client: `python gen_ai/deploy/example.py`

You should see response with all attributes populated