### PR TITLE
Run BQ updates in separate thread

### DIFF
--- a/gen_ai/common/bq_utils.py
+++ b/gen_ai/common/bq_utils.py
@@ -22,11 +22,12 @@ Exceptions:
 import datetime
 import getpass
 import json
-import uuid
-import git
 import os
 import re
+import uuid
+from typing import Any
 
+import git
 import google.auth
 import pandas as pd
 from google.api_core.exceptions import GoogleAPIError, NotFound
@@ -35,31 +36,8 @@ from google.cloud.bigquery.schema import SchemaField
 
 from gen_ai.common.ioc_container import Container
 from gen_ai.common.memorystore_utils import convert_dict_to_relevancies, convert_dict_to_summaries
-from gen_ai.deploy.model import QueryState
 from gen_ai.constants import MAX_OUTPUT_TOKENS
-
-
-def create_bq_client(project_id: str | None = None) -> bigquery.Client | None:
-    """Creates a BigQuery client.
-    If project_id is not specified, the default project ID will be used.
-    If the default project ID cannot be determined, an error will be raised.
-    Args:
-        project_id (str, optional): The project ID to use. Defaults to None.
-    Returns:
-        A BigQuery client.
-    """
-    if project_id is None:
-        try:
-            _, project_id = google.auth.default()
-        except GoogleAPIError as e:
-            print(f"Failed to authenticate: {e}")
-            return None
-    try:
-        client = bigquery.Client(project=project_id)
-    except GoogleAPIError as e:
-        print(f"Failed to create BigQuery client: {e}")
-        return None
-    return client
+from gen_ai.deploy.model import Conversation, QueryState
 
 
 def create_dataset(
@@ -115,17 +93,41 @@ def create_table(
         table = client.create_table(table)
         print(f"Table {table_id} created.")
 
+def load_data_to_bq(conversation: Conversation, log_snapshots: list[dict[str, Any]]):
+    """Loads prediction data, question and exeriments information to BigQuery.
 
-def load_data_to_bq(client: bigquery.Client, table_id: str, schema: list[SchemaField], df: pd.DataFrame) -> None:
+    This function prepares and loads relevant data from a conversation into BigQuery. 
+    The process involves extracting the latest question from the conversation, 
+    logging it for reference, and transforming the data into a format
+    suitable for BigQuery using the `BigQueryConverter`.
+
+    Args:
+        conversation: A Conversation object containing the full conversation history.
+        log_snapshots: A list of log snapshot objects containing relevant metadata.
+    """
+    query_state = conversation.exchanges[-1]
+    question = query_state.question
+    log_question(question)
+    df = BigQueryConverter.convert_query_state_to_prediction(
+        conversation.exchanges[-1], log_snapshots, conversation.session_id
+    )
+    load_prediction_data_to_bq(df)
+
+
+def load_prediction_data_to_bq(df: pd.DataFrame) -> None:
     """Loads data from a pandas DataFrame to a BigQuery table.
     The table will be created if it does not already exist.
     If the table already exists, it will be overwritten.
     Args:
-        client (bigquery.Client): The BigQuery client.
-        table_id (str): The ID of the table to load data to.
-        schema (List[bigquery.SchemaField]): The schema of the table.
         df (pandas.DataFrame): The DataFrame to load data from.
     """
+    client = Container.logging_bq_client()
+    dataset_id = get_dataset_id()
+
+    table_id = f"{dataset_id}.prediction"
+    table = client.get_table(table_id)
+    schema = table.schema
+
     job_config = bigquery.LoadJobConfig(schema=schema)
     job = None
     try:
@@ -226,7 +228,7 @@ def insert_data_to_table(table_name: str, data: dict[str, str]) -> bool:
     Returns:
         bool: True if the insertion was successful, False otherwise.
     """
-    client = create_bq_client()
+    client = Container.logging_bq_client()
     dataset_id = get_dataset_id()
     table = client.get_table(f"{dataset_id}.{table_name}") 
 

--- a/gen_ai/common/document_retriever.py
+++ b/gen_ai/common/document_retriever.py
@@ -113,7 +113,7 @@ class SemanticDocumentRetriever(DocumentRetriever):
             metadata = convert_to_chroma_format(metadata)
 
         ss_docs = store.similarity_search_with_score(query=questions_for_search, k=50, filter=metadata)
-        ss_docs = [x[0] for x in ss_docs[0:2]]
+        ss_docs = [x[0] for x in ss_docs[0:3]]
 
         if Container.config.get("use_mmr", False):
             mmr_docs = store.max_marginal_relevance_search(

--- a/gen_ai/common/ioc_container.py
+++ b/gen_ai/common/ioc_container.py
@@ -26,10 +26,14 @@ Usage:
 
 import logging
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from logging import Logger
 
+import google.auth
 import redis
 from dependency_injector import containers, providers
+from google.api_core.exceptions import GoogleAPIError
+from google.cloud import bigquery
 from langchain.chains import LLMChain
 from langchain.chains.base import Chain
 from langchain.prompts import PromptTemplate
@@ -40,9 +44,32 @@ import gen_ai.common.common as common
 from gen_ai.common.embeddings_provider import EmbeddingsProvider
 from gen_ai.common.exponential_retry import LLMExponentialRetryWrapper
 from gen_ai.common.storage import UhgStorage
-from gen_ai.common.vector_provider import VectorStrategy, VectorStrategyProvider
+from gen_ai.common.vector_provider import (VectorStrategy,
+                                           VectorStrategyProvider)
 from gen_ai.constants import LLM_YAML_FILE, MEMORY_STORE_IP
 
+
+def create_bq_client(project_id: str | None = None) -> bigquery.Client | None:
+    """Creates a BigQuery client.
+    If project_id is not specified, the default project ID will be used.
+    If the default project ID cannot be determined, an error will be raised.
+    Args:
+        project_id (str, optional): The project ID to use. Defaults to None.
+    Returns:
+        A BigQuery client.
+    """
+    if project_id is None:
+        try:
+            _, project_id = google.auth.default()
+        except GoogleAPIError as e:
+            print(f"Failed to authenticate: {e}")
+            return None
+    try:
+        client = bigquery.Client(project=project_id)
+    except GoogleAPIError as e:
+        print(f"Failed to create BigQuery client: {e}")
+        return None
+    return client
 
 def provide_chain(template_name: str, input_variables: list[str], output_key: str, llm: LLMChain = None) -> Chain:
     """
@@ -148,6 +175,11 @@ class Container(containers.DeclarativeContainer):
         vector_indices (Chroma): Chroma vector indices initialized based on configuration.
         redis_db (Provider): Provides a Redis database connection.
         debug_info (bool): Indicates whether debugging is enabled.
+        system_state_id (str | None): System state id
+        question_id (str | None): Question id
+        logging_bq_executor (Provider): Provides Thread Pool Executor
+        logging_bq_client (Provider): Provides BigQuery client
+
 
     Usage:
         Components from the container can be accessed as attributes and are instantiated as needed with configurations
@@ -191,3 +223,5 @@ class Container(containers.DeclarativeContainer):
     comments = "None"
     system_state_id = None
     question_id = None
+    logging_bq_executor = providers.Singleton(ThreadPoolExecutor, max_workers=1)
+    logging_bq_client = providers.Singleton(create_bq_client, config.get("bq_project_id"))

--- a/gen_ai/create_tables.py
+++ b/gen_ai/create_tables.py
@@ -41,7 +41,7 @@ import argparse
 
 from google.cloud import bigquery
 
-from gen_ai.common.bq_utils import create_bq_client, create_dataset, create_table, get_dataset_id
+from gen_ai.common.bq_utils import create_dataset, create_table, get_dataset_id
 from gen_ai.common.ioc_container import Container
 
 schema_gt = [
@@ -118,8 +118,7 @@ if __name__ == "__main__":
     parser.add_argument("--recreate_table", action="store_true", help="Flag to recreate the tables")
     args = parser.parse_args()
 
-    project_id = Container.config["bq_project_id"]
-    client = create_bq_client(project_id=project_id)
+    client = Container.logging_bq_client()
     dataset_id = get_dataset_id()
 
     create_dataset(client, dataset_id, recreate_dataset=args.recreate_dataset)


### PR DESCRIPTION
# Summary
This change allows to run BQ dump in separate thread, hence improve latency of response generation.
Want to optimize `load_to_bq` function later, so as lower functions don't need to make separate trips to get client, dataset_id etc. 

# Testing
Tested manually using `check_pipeline step` and using prints to assure BQ writes happen after return of response and does not affect model response time. Also made sure BQ tables are updated
