### PR TITLE
Fix session id separate

### DIFF
--- a/gen_ai/check_pipeline.py
+++ b/gen_ai/check_pipeline.py
@@ -108,7 +108,6 @@ def run_pipeline(mode: Literal["batch", "step"] = "step", csv_path: str = None, 
         Measures and displays execution time in 'step' mode.
     """
     session_id = str(uuid.uuid4())
-    Container.session_id = session_id
     Container.logger().info(msg=f"Session id is: {session_id}")
     Container.comments = comments
     if mode == "batch":
@@ -121,6 +120,7 @@ def run_pipeline(mode: Literal["batch", "step"] = "step", csv_path: str = None, 
 
             if Container.config.get("personalization"):
                 personalized_data = get_default_personalized_info(row)
+                personalized_data["session_id"] = session_id
             answer = run_single_prediction(question, personalized_data)
             Container.logger().info(msg=f"Answer: {answer}")
     elif mode == "step":
@@ -128,7 +128,9 @@ def run_pipeline(mode: Literal["batch", "step"] = "step", csv_path: str = None, 
         for idx, input_query in enumerate(["Do I have a copay for a routine colonoscopy?"]):
             Container.logger().info(msg=f"Asking question {idx} in document ")
             Container.logger().info(msg=f"Question: {input_query}")
-            answer = run_single_prediction(input_query, {"set_number": "001acis"})
+            answer = run_single_prediction(
+                input_query, {"set_number": "001acis", "member_id": "q123", "session_id": "123"}
+            )
             Container.logger().info(msg=f"Answer: {answer}")
         end = default_timer()
         print(f"Total flow took {end - start} seconds")

--- a/gen_ai/common/document_retriever.py
+++ b/gen_ai/common/document_retriever.py
@@ -23,21 +23,23 @@ from gen_ai.common.chroma_utils import convert_to_chroma_format
 from gen_ai.common.ioc_container import Container
 
 
-def remove_member_id(metadata: dict[str, Any]) -> dict[str, Any]:
-    """Removes the "member_id" key from a metadata dictionary.
+def remove_member_and_session_id(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Removes the "member_id" key and "session_id" from a metadata dictionary.
 
-    This function creates a copy of the input dictionary, deletes the "member_id" key from
+    This function creates a copy of the input dictionary, deletes the "member_id" and "session_id" key from
     the copy, and returns the modified copy.
 
     Args:
         metadata (dict): The input metadata dictionary.
 
     Returns:
-        dict: A new dictionary with the "member_id" key removed.
+        dict: A new dictionary with the "member_id" and "session_id" key removed.
     """
     new_metadata = copy.deepcopy(metadata)
     if "member_id" in new_metadata:
         del new_metadata["member_id"]
+    if "session_id" in new_metadata:
+        del new_metadata["session_id"]
     return new_metadata
 
 
@@ -108,7 +110,7 @@ class SemanticDocumentRetriever(DocumentRetriever):
     ) -> list[Document]:
         if metadata is None:
             metadata = {}
-        metadata = remove_member_id(metadata)
+        metadata = remove_member_and_session_id(metadata)
         if metadata is not None and len(metadata) > 1:
             metadata = convert_to_chroma_format(metadata)
 

--- a/gen_ai/common/memorystore_utils.py
+++ b/gen_ai/common/memorystore_utils.py
@@ -18,22 +18,28 @@ from langchain.schema import Document
 from gen_ai.common.ioc_container import Container
 from gen_ai.deploy.model import PersonalizedData, QueryState
 
+DEFAULT_SESSION_ID = "123456789"
 
-def generate_query_state_key(personalized_data: PersonalizedData, unique_identifier: str | None = None) -> str:
+
+def generate_query_state_key(personalized_data: dict[str, str], unique_identifier: str | None = None) -> str:
     """
     Generates a unique key for storing a query state in Redis.
 
-    The key is constructed using the policy number and set number from the personalized data, along with a
+    The key is constructed using the member id number and set number from the personalized data, along with a
     unique identifier.
 
     Args:
-        personalized_data (PersonalizedData): The personalized data containing the policy and set number.
+        personalized_data (dict[str, str]): The personalized data containing the policy and set number.
         unique_identifier (str): A unique identifier for the query state, typically a timestamp.
 
     Returns:
         str: A string key uniquely identifying a query state for storage in Redis.
     """
     the_key = f"query_state:{personalized_data['member_id']}:{personalized_data['set_number']}"
+    if "session_id" in personalized_data and personalized_data["session_id"]:
+        the_key = f"{the_key}:{personalized_data['session_id']}"
+    else:
+        the_key = f"{the_key}:{DEFAULT_SESSION_ID}"
     if unique_identifier:
         the_key = f"{the_key}:{unique_identifier}"
     return the_key

--- a/gen_ai/llm.py
+++ b/gen_ai/llm.py
@@ -476,7 +476,10 @@ def respond(conversation: Conversation, member_info: dict) -> Conversation:
         Exception: If issues arise in conversation processing or during response generation.
     """
     conversation.member_info = member_info
-
+    if conversation.member_info and "session_id" in conversation.member_info:
+        conversation.session_id = conversation.member_info["session_id"]
+    else:
+        conversation.session_id = str(uuid.uuid4())
     api_mode = Container.config.get("api_mode", "stateless")
     statefullness_enabled = api_mode == "stateful"
     if statefullness_enabled:
@@ -486,9 +489,6 @@ def respond(conversation: Conversation, member_info: dict) -> Conversation:
 
     if statefullness_enabled:
         serialize_response(conversation)
-
-    session_id = Container.session_id if hasattr(Container, "session_id") else str(uuid.uuid4())
-    conversation.session_id = session_id
 
     Container.logging_bq_executor().submit(load_data_to_bq, conversation, log_snapshots)
 


### PR DESCRIPTION
## Description
This PR uses the session_id from conversation instead of Container. This ensures that we dont save in background threads different conversations