### PR TITLE
Apply cloud logging on standard python log handler

### DIFF
--- a/gen_ai/common/ioc_container.py
+++ b/gen_ai/common/ioc_container.py
@@ -30,6 +30,7 @@ from concurrent.futures import ThreadPoolExecutor
 from logging import Logger
 
 import google.auth
+import google.cloud.logging
 import redis
 from dependency_injector import containers, providers
 from google.api_core.exceptions import GoogleAPIError
@@ -133,6 +134,8 @@ def provide_vector_indices(regenerate: bool = False) -> Chroma:
 
 
 def provide_logger() -> Logger:
+    client = google.cloud.logging.Client()
+    client.setup_logging()
     stdout_handler = logging.StreamHandler(stream=sys.stdout)
     logging.basicConfig(
         level=logging.INFO,

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,6 +53,7 @@ google-cloud-aiplatform==1.47.0
 google-cloud-bigquery==3.20.1
 google-cloud-core==2.4.1
 google-cloud-documentai==2.25.0
+google-cloud-logging==3.10.0
 google-cloud-resource-manager==1.12.3
 google-cloud-storage==2.16.0
 google-crc32c==1.5.0


### PR DESCRIPTION
# Summary

Switch logging to Google Cloud, by attaching the Cloud Logging handler to the Python root logger.

# Testing

Tested manually using check_pipeline. Ensured getting response, writing logs into cloud and writing to BQ.